### PR TITLE
Make textureStore public in Game

### DIFF
--- a/BloomFramework/include/Game.h
+++ b/BloomFramework/include/Game.h
@@ -25,9 +25,6 @@ namespace bloom {
 		void handleEvents();
 		bool isRunning();
 
-		TexturePtr loadTexture(const std::string & filePath, std::optional<SDL_Color> colorKey = std::nullopt);
-		void unloadTexture(const std::string & filePath);
-
 		void setColor(SDL_Color const& color);
 		void setColor(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
@@ -37,6 +34,8 @@ namespace bloom {
 		int getScreenHeight();
 		SDL_Event getEvent();
 
+		TextureStore	textureStore = TextureStore(m_renderer);
+
 	protected:
 		SDL_Renderer *	m_renderer = nullptr;
 		SDL_Window *	m_window = nullptr;
@@ -45,6 +44,5 @@ namespace bloom {
 		SDL_Color		m_color;
 		SDL_Event		m_event;
 		bool			m_isRunning;
-		TextureStore	m_textureStore = TextureStore(m_renderer);
 	};
 }

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -131,14 +131,6 @@ namespace bloom {
 		return m_isRunning;
 	}
 
-	TexturePtr Game::loadTexture(const std::string & filePath, std::optional<SDL_Color> colorKey) {
-		return m_textureStore.load(filePath, colorKey);
-	}
-
-	void Game::unloadTexture(const std::string & filePath) {
-		m_textureStore.unload(filePath);
-	}
-
 	void Game::setColor(const SDL_Color & color) {
 		m_color = color;
 		SDL_SetRenderDrawColor(m_renderer, m_color.a, m_color.g, m_color.b, m_color.a);

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -29,11 +29,11 @@ int main() {
 	static_cast<Uint8>(rand() % 255), static_cast<Uint8>(rand() % 255) };
 	game->setColor(randColor);
 	game->render();
-	auto testSprite = game->loadTexture("Assets/OverworldTestSpritesheet.png", SDL_Color{ 64, 176, 104, 113 });
+	auto testSprite = game->textureStore.load("Assets/OverworldTestSpritesheet.png", SDL_Color{ 64, 176, 104, 113 });
 	testSprite->render({ 0,0,32,32 }, { 0,0,128,128 });
 	game->update();
 	game->delay(500);
-	auto testSprite2 = game->loadTexture("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
+	auto testSprite2 = game->textureStore.load("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
 	testSprite2->render({ 0, 0, 32, 32 }, { 128,0,128,128 });
 	game->update();
 	game->delay(500);


### PR DESCRIPTION
textureStore should be public to avoid creating a lot of useless intermediate functions in Game.