### PR TITLE
Fix several graphical oddities

### DIFF
--- a/BloomFramework/include/Game.h
+++ b/BloomFramework/include/Game.h
@@ -10,6 +10,7 @@ namespace bloom {
 
 	public:
 		Game(int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_PRESENTVSYNC);
+		Game(std::nothrow_t,int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_PRESENTVSYNC);
 		~Game();
 
 		static void initialize(Uint32 initFlags = SDL_INIT_EVERYTHING,

--- a/BloomFramework/include/Game.h
+++ b/BloomFramework/include/Game.h
@@ -9,7 +9,7 @@ namespace bloom {
 		friend TextureStore::TextureStore(Game & object);
 
 	public:
-		Game(int width, int height, int windowFlags = NULL, int rendererFlags = NULL);
+		Game(int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_PRESENTVSYNC);
 		~Game();
 
 		static void initialize(Uint32 initFlags = SDL_INIT_EVERYTHING,

--- a/BloomFramework/include/Game.h
+++ b/BloomFramework/include/Game.h
@@ -9,8 +9,8 @@ namespace bloom {
 		friend TextureStore::TextureStore(Game & object);
 
 	public:
-		Game(int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_PRESENTVSYNC);
-		Game(std::nothrow_t,int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_PRESENTVSYNC);
+		Game(int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+		Game(std::nothrow_t, int width, int height, int windowFlags = NULL, int rendererFlags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
 		~Game();
 
 		static void initialize(Uint32 initFlags = SDL_INIT_EVERYTHING,

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -12,7 +12,7 @@ namespace bloom {
 		if (SDL_WasInit(0) == 0)
 			initialize();
 
-		if (windowFlags & 1 == 1) {
+		if (windowFlags != 4097 && windowFlags & 1 == 1) {
 			throw Exception("Exclusive fullscreen is not recommended due to graphic oddities when using hardware acceleration.");
 		}
 	}

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -5,12 +5,15 @@ namespace bloom {
 	Game::Game(int width, int height, int windowFlags, int rendererFlags) :
 		m_screenWidth(width),
 		m_screenHeight(height),
-		m_windowFlags(windowFlags),
+		m_windowFlags(windowFlags & 1 ? windowFlags ^ 1 : windowFlags),
 		m_rendererFlags(rendererFlags),
 		m_isRunning(false)
 	{
 		if (SDL_WasInit(0) == 0)
 			initialize();
+
+		if (windowFlags & 1 == 1)
+			std::cerr << "Exclusive fullscreen is not recommended. Flag unset." << std::endl;
 	}
 
 	Game::~Game() {
@@ -99,8 +102,6 @@ namespace bloom {
 
 	void Game::update() {
 		std::clog << "Delta time: " << timer.lap() << std::endl;
-		// Nothing here yet.
-		SDL_RenderPresent(m_renderer);
 	}
 
 	void Game::clear() {
@@ -112,11 +113,6 @@ namespace bloom {
 	}
 
 	void Game::render() {
-		SDL_RenderClear(m_renderer);
-		// For texture rendering test.
-		//auto tmp = m_textureStore.load("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
-		//tmp->render({ 0,32,32,32 }, { 0,0,192,192 }); 
-		// Testing ends here.
 		SDL_RenderPresent(m_renderer);
 	}
 

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -5,15 +5,16 @@ namespace bloom {
 	Game::Game(int width, int height, int windowFlags, int rendererFlags) :
 		m_screenWidth(width),
 		m_screenHeight(height),
-		m_windowFlags((windowFlags & 1) ? (windowFlags ^ 1) : windowFlags),
+		m_windowFlags(windowFlags),
 		m_rendererFlags(rendererFlags),
 		m_isRunning(false)
 	{
 		if (SDL_WasInit(0) == 0)
 			initialize();
 
-		if (windowFlags & 1 == 1)
-			std::cerr << "Exclusive fullscreen is not recommended. Flag unset." << std::endl;
+		if (windowFlags & 1 == 1) {
+			throw Exception("Exclusive fullscreen is not recommended due to graphic oddities when using hardware acceleration.");
+		}
 	}
 
 	Game::~Game() {

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -12,11 +12,11 @@ namespace bloom {
 		if (SDL_WasInit(0) == 0)
 			initialize();
 
-		if (windowFlags != 4097 && windowFlags & 1 == 1) {
+		if ((windowFlags & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN && (windowFlags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
 			throw Exception("Exclusive fullscreen is not recommended due to graphic oddities when using hardware acceleration.");
 		}
 	}
-	Game::Game(std::nothrow_t ,int width, int height, int windowFlags, int rendererFlags) :
+	Game::Game(std::nothrow_t, int width, int height, int windowFlags, int rendererFlags) :
 		m_screenWidth(width),
 		m_screenHeight(height),
 		m_windowFlags(windowFlags),
@@ -25,6 +25,8 @@ namespace bloom {
 	{
 		if (SDL_WasInit(0) == 0)
 			initialize();
+
+		std::clog << "[Game] the use of this ctor may be unsafe" << std::endl;
 	}
 
 	Game::~Game() {

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -5,7 +5,7 @@ namespace bloom {
 	Game::Game(int width, int height, int windowFlags, int rendererFlags) :
 		m_screenWidth(width),
 		m_screenHeight(height),
-		m_windowFlags(windowFlags & 1 ? windowFlags ^ 1 : windowFlags),
+		m_windowFlags((windowFlags & 1) ? (windowFlags ^ 1) : windowFlags),
 		m_rendererFlags(rendererFlags),
 		m_isRunning(false)
 	{

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -16,6 +16,16 @@ namespace bloom {
 			throw Exception("Exclusive fullscreen is not recommended due to graphic oddities when using hardware acceleration.");
 		}
 	}
+	Game::Game(std::nothrow_t ,int width, int height, int windowFlags, int rendererFlags) :
+		m_screenWidth(width),
+		m_screenHeight(height),
+		m_windowFlags(windowFlags),
+		m_rendererFlags(rendererFlags),
+		m_isRunning(false)
+	{
+		if (SDL_WasInit(0) == 0)
+			initialize();
+	}
 
 	Game::~Game() {
 		destroy();

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -17,6 +17,7 @@ int main() {
 		system("pause");
 		exit(-1);
 	}
+	
 	game = new Game(800, 600,1);
 	try {
 		game->create("Bloom Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -18,7 +18,7 @@ int main() {
 		exit(-1);
 	}
 	
-	game = new Game(800, 600);
+	game = new Game(std::nothrow, 800, 600);
 	try {
 		game->create("Bloom Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -5,7 +5,7 @@ using namespace bloom;
 Game* game = nullptr;
 
 int main() {
-	const int fps = 1;
+	const int fps = 60;
 	const int framedelay = (1000 / fps);
 
 	Uint32 framestart;
@@ -17,7 +17,7 @@ int main() {
 		system("pause");
 		exit(-1);
 	}
-	game = new Game(1366, 768,1);
+	game = new Game(800, 600,1);
 	try {
 		game->create("Bloom Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -5,7 +5,7 @@ using namespace bloom;
 Game* game = nullptr;
 
 int main() {
-	const int fps = 60;
+	const int fps = 1;
 	const int framedelay = (1000 / fps);
 
 	Uint32 framestart;
@@ -17,7 +17,7 @@ int main() {
 		system("pause");
 		exit(-1);
 	}
-	game = new Game(800, 600);
+	game = new Game(1366, 768,1);
 	try {
 		game->create("Bloom Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
@@ -28,28 +28,24 @@ int main() {
 	SDL_Color randColor = { static_cast<Uint8>(rand() % 255), static_cast<Uint8>(rand() % 255),
 	static_cast<Uint8>(rand() % 255), static_cast<Uint8>(rand() % 255) };
 	game->setColor(randColor);
-	game->render();
+	game->clear();
 	auto testSprite = game->textureStore.load("Assets/OverworldTestSpritesheet.png", SDL_Color{ 64, 176, 104, 113 });
 	testSprite->render({ 0,0,32,32 }, { 0,0,128,128 });
-	game->update();
+	game->render();
 	game->delay(500);
 	auto testSprite2 = game->textureStore.load("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
 	testSprite2->render({ 0, 0, 32, 32 }, { 128,0,128,128 });
-	game->update();
+	game->render();
 	game->delay(500);
+	
 	while (game->isRunning()) {
+		game->clear();
 		framestart = SDL_GetTicks();
 		game->handleEvents();
-		game->clear();
-		try {
-			game->render();
-		}
-		catch (Exception & e) {
-			std::cerr << e.what() << std::endl;
-		}
 		testSprite->render({ 0, 0, 32, 32 }, { static_cast<uint16_t>(rand() % 672), static_cast<uint16_t>(rand() % 472), 128, 128 });
 		testSprite2->render({ 0, 0, 32, 32 }, { static_cast<uint16_t>(rand() % 672), static_cast<uint16_t>(rand() % 472), 128, 128 });
 		game->update();
+		game->render();
 		int frametime = SDL_GetTicks() - framestart;
 
 		if (framedelay > frametime)

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -18,7 +18,7 @@ int main() {
 		exit(-1);
 	}
 	
-	game = new Game(800, 600,1);
+	game = new Game(800, 600);
 	try {
 		game->create("Bloom Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}


### PR DESCRIPTION
Fixes #11.

* `update()` and `render()` functions have been reworked slightly.
* V-Sync is now enabled by default.
* `Game` constructor by default will now throw exception when using `SDL_WINDOW_FULLSCREEN` flag.
  * Providing std::nothrow to the overloaded constructor bypasses the exception.