### PR TITLE
Fixes and improvements to Texture and related

### DIFF
--- a/BloomFramework/include/Game.h
+++ b/BloomFramework/include/Game.h
@@ -36,8 +36,8 @@ namespace bloom {
 		int getScreenHeight();
 		SDL_Event getEvent();
 
-		TextureStore	textureStore = TextureStore(m_renderer);
-		Timer timer;
+		TextureStore	textures = TextureStore(m_renderer);
+		Timer			timer;
 
 	protected:
 		SDL_Renderer *	m_renderer = nullptr;

--- a/BloomFramework/include/Texture.h
+++ b/BloomFramework/include/Texture.h
@@ -13,4 +13,6 @@ namespace bloom {
 		SDL_Texture *	m_texture;
 		SDL_Renderer *&	m_renderer;
 	};
+
+	using TexturePtr = std::shared_ptr<Texture>;
 }

--- a/BloomFramework/include/TextureStore.h
+++ b/BloomFramework/include/TextureStore.h
@@ -7,9 +7,6 @@
 
 namespace bloom {
 	class Game;
-
-	typedef std::shared_ptr<Texture> TexturePtr;
-
 	//template class BLOOMFRAMEWORK_API std::unordered_map<std::string, TexturePtr>;
 
 	class BLOOMFRAMEWORK_API TextureStore {
@@ -18,13 +15,11 @@ namespace bloom {
 		TextureStore(Game & renderer);
 
 		TexturePtr load(const std::string & filePath, std::optional<SDL_Color> colorKey = std::nullopt);
-		TexturePtr getTexture(const std::string & filePath);
+		TexturePtr find(const std::string & filePath);
+		TexturePtr find(std::nothrow_t, const std::string & filePath);
 		void unload(const std::string & filePath);
  
-
 	private:
-		TexturePtr findTexture(const std::string & filePath);
-
 		SDL_Renderer *&	m_renderer;
 		std::unordered_map<std::string, TexturePtr>	m_store;
 	};

--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -16,6 +16,7 @@ namespace bloom {
 			throw Exception("Exclusive fullscreen is not recommended due to graphic oddities when using hardware acceleration.");
 		}
 	}
+
 	Game::Game(std::nothrow_t, int width, int height, int windowFlags, int rendererFlags) :
 		m_screenWidth(width),
 		m_screenHeight(height),

--- a/BloomFramework/src/TextureStore.cpp
+++ b/BloomFramework/src/TextureStore.cpp
@@ -8,9 +8,9 @@ namespace bloom {
 
 	TexturePtr TextureStore::load(const std::string & filePath, std::optional<SDL_Color> colorKey) {
 		// Check if texture of the same path is loaded. If so, return shared_ptr of texture.
-		auto texture = findTexture(filePath);
-		if (texture != nullptr)
-			return texture;
+		auto textureIt = m_store.find(filePath);
+		if (textureIt != m_store.end())
+			return textureIt->second;
 
 		//Load image at specified path
 		SDL_Surface* loadedSurface = IMG_Load(filePath.c_str());
@@ -38,7 +38,7 @@ namespace bloom {
 		}
 	}
 
-	TexturePtr TextureStore::getTexture(const std::string & filePath) {
+	TexturePtr TextureStore::find(const std::string & filePath) {
 		auto texIterator = m_store.find(filePath);
 		if (texIterator != m_store.end())
 			return texIterator->second;
@@ -47,20 +47,19 @@ namespace bloom {
 		}
 	}
 
+	TexturePtr TextureStore::find(std::nothrow_t, const std::string & filePath) {
+		auto texIterator = m_store.find(filePath);
+		if (texIterator != m_store.end())
+			return texIterator->second;
+		else {
+			return nullptr;
+		}
+	}
+
 	void TextureStore::unload(const std::string & filePath) {
 		auto texIterator = m_store.find(filePath);
 		if (texIterator != m_store.end())
 			m_store.erase(texIterator);
 		// We can't dispose the actual Texture since other's may still be using it.
-	}
-
-	TexturePtr TextureStore::findTexture(const std::string & filePath) {
-		try {
-			auto temp = getTexture(filePath);
-			return temp;
-		}
-		catch (...) {
-			return nullptr;
-		}
 	}
 }

--- a/Test Bench/main.cpp
+++ b/Test Bench/main.cpp
@@ -30,11 +30,11 @@ int main() {
 	static_cast<Uint8>(rand() % 255), static_cast<Uint8>(rand() % 255) };
 	game->setColor(randColor);
 	game->clear();
-	auto testSprite = game->textureStore.load("Assets/OverworldTestSpritesheet.png", SDL_Color{ 64, 176, 104, 113 });
+	auto testSprite = game->textures.load("Assets/OverworldTestSpritesheet.png", SDL_Color{ 64, 176, 104, 113 });
 	testSprite->render({ 0,0,32,32 }, { 0,0,128,128 });
 	game->render();
 	game->delay(500);
-	auto testSprite2 = game->textureStore.load("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
+	auto testSprite2 = game->textures.load("Assets/TestChar.png", SDL_Color{ 144,168,0,0 });
 	testSprite2->render({ 0, 0, 32, 32 }, { 128,0,128,128 });
 	game->render();
 	game->delay(500);


### PR DESCRIPTION
- rework texture search in ```TextureStore::load()```
- remove private method ```TextureStore::findTexture(...)```
- rename ```TextureStore::getTexture(...) to TextureStore::find(...)```
- add method for texture search w/o Exception (```TextureStore::find(std::nothrow_t,...)```)
- move definition of ```TexturePtr``` from ```TextureStore.h``` to the end of ```Texture.h``` and replace ```typedef``` with ```using```
- rename ```textureStore``` to ```textures``` in ```Game.h```

***I don't want to fill this PR template so i remove it.***