### PR TITLE
[Game] Fixed bug in setColor

### DIFF
--- a/BloomFramework/src/Game.cpp
+++ b/BloomFramework/src/Game.cpp
@@ -160,12 +160,12 @@ namespace bloom {
 
 	void Game::setColor(const SDL_Color & color) {
 		m_color = color;
-		SDL_SetRenderDrawColor(m_renderer, m_color.a, m_color.g, m_color.b, m_color.a);
+		SDL_SetRenderDrawColor(m_renderer, m_color.r, m_color.g, m_color.b, m_color.a);
 	}
 
 	void Game::setColor(Uint8 r, Uint8 g, Uint8 b, Uint8 a) {
 		m_color = { r, g, b, a };
-		SDL_SetRenderDrawColor(m_renderer, m_color.a, m_color.g, m_color.b, m_color.a);
+		SDL_SetRenderDrawColor(m_renderer, m_color.r, m_color.g, m_color.b, m_color.a);
 	}
 
 	SDL_Color Game::getColor() {


### PR DESCRIPTION
Instead of the red color value, the alpha value was used in SDL_SetRenderDrawColor as red color