### PR TITLE
Utilize multi-processor operations in builds

### DIFF
--- a/BloomFramework.sln
+++ b/BloomFramework.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28315.86
@@ -9,6 +8,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Test Bench", "Test Bench\Te
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D20B0FF1-C538-4E21-8AAF-785C13282F52}"
 	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/BloomFramework/BloomFramework.vcxproj
+++ b/BloomFramework/BloomFramework.vcxproj
@@ -99,6 +99,7 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>NotSet</SubSystem>
@@ -116,6 +117,7 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link />
     <Link>
@@ -136,6 +138,7 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -156,6 +159,7 @@
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Test Bench/Test Bench.vcxproj
+++ b/Test Bench/Test Bench.vcxproj
@@ -96,6 +96,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <PreprocessorDefinitions>BLOOM_DEBUG;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <PostBuildEvent>
       <Command>(robocopy "$(ProjectDir)data\\" "$(OutDir)data\\" /S /NDL /NJH /NJS /nc /ns /np) ^&amp; IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0</Command>
@@ -118,6 +119,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <PreprocessorDefinitions>BLOOM_DEBUG;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -142,6 +144,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <PreprocessorDefinitions>BLOOM_DEBUG;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -168,6 +171,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <PreprocessorDefinitions>BLOOM_DEBUG;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,45 +12,49 @@ trigger:
 pr:
 - '*'
 
-pool:
-  vmImage: 'windows-2019'
-  demands:
-  - 'msbuild'
-  - 'visualstudio'
+jobs:
+- job: BloomFramework
+  pool:
+    vmImage: 'windows-2019'
+    demands:
+    - 'msbuild'
+    - 'visualstudio'
 
-variables:
-  solution: '**/*.sln'
+  variables:
+    solution: '*.sln'
 
-strategy:
-  matrix:
-    debug-x86:
-      buildPlatform: 'x86'
-      buildConfiguration: 'Debug'
-    debug-x64:
-      buildPlatform: 'x64'
-      buildConfiguration: 'Debug'
-    release-x86:
-      buildPlatform: 'x86'
-      buildConfiguration: 'Release'
-    release-x64:
-      buildPlatform: 'x64'
-      buildConfiguration: 'Release'
+  strategy:
+    maxParallel: 10
+    matrix:
+      debug-x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Debug'
+      debug-x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Debug'
+      release-x86:
+        buildPlatform: 'x86'
+        buildConfiguration: 'Release'
+      release-x64:
+        buildPlatform: 'x64'
+        buildConfiguration: 'Release'
 
-steps:
-- checkout: 'self'
-  lfs: true
-  submodules: 'recursive'
+  steps:
+  - checkout: 'self'
+    lfs: true
+    submodules: 'recursive'
 
-- task: NuGetCommand@2
-  displayName: 'Restore NuGet packages'
-  inputs:
-    restoreSolution: '$(solution)'
-    verbosityRestore: 'Normal'
+  - task: NuGetCommand@2
+    displayName: 'Restore NuGet packages'
+    inputs:
+      restoreSolution: '$(solution)'
+      verbosityRestore: 'Normal'
 
-- task: VSBuild@1
-  displayName: 'Build solution'
-  inputs:
-    solution: '$(solution)'
-    vsVersion: '16.0'
-    platform: '$(buildPlatform)'
-    configuration: '$(buildConfiguration)'
+  - task: VSBuild@1
+    displayName: 'Build solution $(solution)'
+    inputs:
+      solution: '$(solution)'
+      vsVersion: '16.0'
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'
+      maximumCpuCount: true


### PR DESCRIPTION
The compilation process could make use of the large amount of cores/threads available on modern systems to improve build times.

This project doesn't use [incompatible options and language features](https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=vs-2019#incompatible-options-and-language-features) that conflicts with the `/mp` flag, so we could safely enable it.

Observed timings on 4C/8T Ryzen (clean build):
Before: 38987ms + 4229ms = 43216 ms
After: 9162ms + 3464ms = 12626 ms (-30590ms, 70.78% improvement)
<sub>Pipelines VM only has 2 Virtual cores, so build times there is less significant, but an average of 20s improvement can still be observed</sub>



ps: Hacktoberfest PR season XD